### PR TITLE
Added the .copy operator to ensure passing by value.

### DIFF
--- a/bin/sos
+++ b/bin/sos
@@ -88,16 +88,16 @@ def d2a(D, perplexity, tol=1e-5):
         # Evaluate whether the perplexity is within tolerance
         Hdiff = H - logU
         tries = 0
-        while np.abs(Hdiff) > tol and tries < 50:
+        while np.abs(Hdiff) > tol and tries < 5000:
             # If not, increase or decrease precision
             if Hdiff > 0:
-                betamin = beta[i]
+                betamin = beta[i].copy()
                 if betamax == np.inf or betamax == -np.inf:
                     beta[i] = beta[i] * 2.0
                 else:
                     beta[i] = (beta[i] + betamax) / 2.0
             else:
-                betamax = beta[i]
+                betamax = beta[i].copy()
                 if betamin == np.inf or betamin == -np.inf:
                     beta[i] = beta[i] / 2.0
                 else:


### PR DESCRIPTION
Hi Jeroen Janssens,

I think I have found a bug in the Python implementation. Currently I am working on an implementation in Scala for the Apache Spark platform the scale the algorithm across a large number of clusters. I used the Python script to create unit-tests to verify the workings of the algorithm. I could not find any obvious mistakes, so I did a step by step comparison.

Within Scala the values are assigned as an immutable value which is different as in Python. I found out that this caused a difference in result. To mimic this behavior I added the `.copy()` method on the value which gives a copy. Otherwise, for example `beta[i] == 1`, `betamax == inf` and `Hdiff <= 0`. `betamax` gets assigned as `1`, which is the value of `beta at that moment`, after that the precision of `beta` gets adjusted to `.5`, and then betamax gets also adjusted to `.5`, which does not seem like a correct behavior to me.

``` python
# If not, increase or decrease precision
if Hdiff > 0:
    betamin = beta[i].copy()
    if betamax == np.inf or betamax == -np.inf:
        beta[i] = beta[i] * 2.0
    else:
        beta[i] = (beta[i] + betamax) / 2.0
else:
    betamax = beta[i].copy()
    if betamin == np.inf or betamin == -np.inf:
        beta[i] = beta[i] / 2.0
    else:
        beta[i] = (beta[i] + betamin) / 2.0
```

Before:

``` python
~/Desktop/sos-correct/bin$ < iris.csv ./sos -p 30 | sort -nr | head
0.92552418
0.91794955
0.81657372
0.79410068
0.77251273
0.76652991
0.71135211
0.69634175
0.69305280
0.68967627
```

After the application of the `.copy()`:

``` python
~/Desktop/sos-correct/bin$ < iris.csv ./sos -p 30 | sort -nr | head
0.88569072
0.82241037
0.74932441
0.71168871
0.69498432
0.68975787
0.67562369
0.66990241
0.65935384
0.65740135
```
