### PR TITLE
Added np.abs before np.sqrt in x2d calculation

### DIFF
--- a/bin/sos
+++ b/bin/sos
@@ -47,7 +47,9 @@ def x2d(X, metric):
     elif metric == 'euclidean':
         log.debug("Computing dissimilarity matrix using Euclidean metric")
         sumX = np.sum(np.square(X), 1)
-        D = np.sqrt(np.add(np.add(-2 * np.dot(X, X.T), sumX).T, sumX))
+	# np.abs protects against extremely small negative values 
+	# that may arise due to floating point arithmetic errors
+        D = np.sqrt( np.abs(np.add(np.add(-2 * np.dot(X, X.T), sumX).T, sumX)) )
     else:
         try:
             from scipy.spatial import distance


### PR DESCRIPTION
I noticed that with the upgrade to numpy 1.11 sos started to return 'nan's with the iris dataset across several computers (I tested on MacOSX and Linux systems). The reason is just before of floating point arithmetic leading to a very small negative number in function x2d, just before the np.sqrt is taken. I simply added np.abs just before np.sqrt to protect against this issue.
