### PR TITLE
Prevent potential infinite loop

### DIFF
--- a/sksos/sos.py
+++ b/sksos/sos.py
@@ -78,7 +78,7 @@ class SOS(object):
             # Evaluate whether the perplexity is within tolerance
             Hdiff = H - logU
             tries = 0
-            while np.isnan(Hdiff) or (np.abs(Hdiff) > self.eps and tries < 5000):
+            while (np.isnan(Hdiff) or np.abs(Hdiff) > self.eps) and tries < 5000:
                 if np.isnan(Hdiff):
                     beta[i] = beta[i] / 10.0
                 # If not, increase or decrease precision


### PR DESCRIPTION
I've encountered some inputs where `np.isnan(Hdiff)` always returned true, leading to the `predict` call looping forever. Maybe the `tries` check was meant to cover the entire loop?